### PR TITLE
docs: add docs for knative integration

### DIFF
--- a/docs/content/user-guides/knative.md
+++ b/docs/content/user-guides/knative.md
@@ -1,0 +1,152 @@
+---
+title: "Traefik Proxy Knative Integration"
+description: "This section of the Traefik Proxy documentation explains how to use Traefik as reverse proxy with Knative."
+---
+# Traefik Knative Integration
+
+## How Knative integrates with Traefik
+
+[Knative][kn] is a popular serverless and event-driven application platform for use with Kubernetes. Knative enables
+workloads that run in Kubernetes to scale to zero, autoscale effectively, have easily managed lifecycles, and more.
+
+In particular, Traefik integrates with [Knative Serving][kn-serving] by providing a powerful and flexible routing layer,
+via the [Kubernetes Gateway API][k8s-gateway] (integrated with Knative via the [`net-gateway-api`][kn-net-gateway-api] layer).
+
+Traefik supports recent versions of [Gateway API][traefik-gateway-api] along with extended features like `TCPRoute` and `TLSRoute`.
+
+!!! info
+    To get started quickly with Gateway API support in Traefik, see ["Getting started with Kubernetes Gateway API and Traefik][community-getting-started-traefik-gateway-api].
+
+[k8s-gateway]: https://gateway-api.sigs.k8s.io/
+[kn]: https://knative.dev/docs/
+[traefik-gateway-api]: https://doc.traefik.io/traefik/providers/kubernetes-gateway/
+[kn-serving]: https://knative.dev/docs/serving/
+[kn-net-gateway-api]: https://github.com/knative-extensions/net-gateway-api
+[community-getting-started-traefik-gateway-api]: https://community.traefik.io/t/getting-started-with-kubernetes-gateway-api-and-traefik/23601
+
+## What you need to get started
+
+To get started, you'll need:
+
+- A Kubernetes cluster with [Gateway API][k8s-gateway] enabled
+- A working Traefik installation with [Gateway API support][traefik-gateway-api] enabled
+- A working Knative installation with Knative serving installed
+  - Knative serving must be configured with the correct `ingress.class` which enables Gateway API (see [`net-gateway-api` instructions][kn-net-gateway-api-instr])
+  - `net-gateway-api` must be installed
+
+!!! info
+    Traefik integration with Knative works via the Gateway API. Consider ensuring that your Gateway API support is working properly independently of Knative first.
+
+[kn-net-gateway-api-instr]: https://github.com/knative-extensions/net-gateway-api?tab=readme-ov-file#getting-started
+
+## Example configuration
+
+This section details an configuration for using Traefik along with Knative and the [`net-gateway-api`][kn-net-gateway-api] (a [Knative networking layer][kn-networking] for Knative) to deploy an example workload.
+
+[kn-networking]: https://github.com/knative/networking
+
+### Configuring Knative to use `net-gateway-api`
+
+To ensure that Knative serving uses `net-gateway-api` (and attempts to create appropriate `HTTPRoute` objects), you must add the following `ConfigMap`:
+
+```yaml tab="Kubernetes"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-network
+  namespace: knative-serving
+data:
+  ingress.class: gateway-api.ingress.networking.knative.dev
+```
+
+### Configuring Traefik as the external gateway for Knative serving (via `net-gateway-api`)
+
+To ensure that when `HTTPRoute`s are created by `net-gateway-api` they are configured to use Traefik, you'll need the `config-gateway` ConfigMap:
+
+```yaml tab="Kubernetes"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-gateway
+  namespace: knative-serving
+data:
+  external-gateways: |
+    - class: traefik
+      gateway: ingress/traefik
+      service: ingress/traefik
+      supported-features:
+        - HTTPRouteRequestTimeout
+```
+
+!!! warning
+    You may need to modify the gateway namespace (`ingress`) and gateway name (`traefik`) above
+
+### Deploying the example workload Knative Serving workload
+
+To start a Knative workload, which will trigger the creation of a dedicated `HTTPRoute`  uses the provided ingress, use:
+
+```yaml tab="Kubernetes"
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: example-go
+spec:
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/knative/helloworld-go@sha256:584dae6fbc79fbf2cd8f94168b75b200d16dd36121eea55845e775aa547b00c8
+          ports:
+            - containerPort: 8080
+          env:
+            - name: TARGET
+              value: Go Sample v1
+```
+
+Creating this [Knative `Service`][kn-service] will trigger the creation of a `HTTPRoute` with Traefik configured as the upstream gateway (via `parentRef`).
+
+For more information on more advanced topics like ([configuring ingress classes][kn-docs-configure-ingress-class]), see the [Knative serving documentation][kn-docs-serving].
+
+[kn-docs-configure-ingress-class]: https://knative.dev/docs/serving/services/ingress-class/
+[kn-service]: https://knative.dev/docs/serving/services/
+[kn-docs-serving]: https://knative.dev/docs/serving/
+
+### Configuring Knative to use a custom domain for the example workload
+
+At this point an *internal* `HTTPRoute` for the Knative service should be available:
+
+```
+kubectl get httproute
+NAME                                   HOSTNAMES                                                                                AGE
+example-go.ingress.svc.cluster.local   ["example-go.ingress","example-go.ingress.svc","example-go.ingress.svc.cluster.local"]   8s
+```
+
+To configure an [external domain for a Knative Service][knative-docs-external-domain], create the following resources:
+
+```yaml tab="Kubernetes"
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: ClusterDomainClaim
+metadata:
+  name: example.localhost
+spec:
+  namespace: default
+```
+
+Once you have a claim on the domain, you can create a mapping for the service we'll create
+
+```yaml tab="Kubernetes"
+apiVersion: serving.knative.dev/v1beta1
+kind: DomainMapping
+metadata:
+  name: example.localhost
+spec:
+  ref:
+    name: example-go
+    kind: Service
+    apiVersion: serving.knative.dev/v1
+```
+
+[knative-docs-external-domain]: https://knative.dev/docs/serving/services/custom-domains/
+
+## Conclusion
+
+Thanks to the flexibility of Traefik in [supporting the Kubernetes Gateway API][traefik-gateway-api], the [Kubernetes Gateway API][gateway-api], and the [`net-gateway-api`][kn-net-gateway-api] networking layer available for Knative, Traefik can now easily serve as a networking layer for Knative.


### PR DESCRIPTION
Hey I've started some work on the docs for the integration!

I've had some problem getting this working locally -- I can't get k3s to give my `Gateway` an address -- the `GatewayClass` comes up fine, and all the CRDs are installed and the setup is working (using an `IngressRoute` works, for example, I can `curl -H 'Host: ...'` to test), but for some reason Traefik won't give the `Gateway` an address (which should just be the address of the single worker node).

I've even tried manually specifying an address:

```yaml
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: web
spec:
  gatewayClassName: traefik
  addresses:
    - type: IPAddress
      value: "172.18.0.2" # local single worker node's IP, Traefik is deployed as a DS w/ node acccess.
      
  listeners:
    - name: web # this is the traefik listener
      protocol: HTTP
      port: 80
      allowedRoutes:
        namespaces:
          from: All
```

Any help would be appreciated! It took quite a bit to use get a working `k3s` config based on what was used in the Traefik codebase (I need to make some PRs there... I have no idea how someone runs a local version of traefik easily), but I got your custom build running to test, only stopper right now seems to be Gateway API integration not actually working properly.

Also, oddly, none of the gateway routes show up in Traefik dashboard either, so hard to tell what is wrong. Biggest problem has to be that the Gateway doesn't have an address:

```
➜ k get gateway
NAME   CLASS     ADDRESS   PROGRAMMED   AGE
web    traefik             True         9m5s
```

Relevant but incomplete issue:

https://community.traefik.io/t/how-to-get-an-ip-address-for-gateway-api/23941